### PR TITLE
support keepAlive option

### DIFF
--- a/tasks/protractor_coverage.js
+++ b/tasks/protractor_coverage.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var opts = this.options({
       configFile: (!grunt.util._.isUndefined(this.data.configFile)) ? this.data.configFile : protractorRefConfPath,
-      keepAlive: true,
+      keepAlive: (!grunt.util._.isUndefined(this.data.keepAlive)) ? this.data.keepAlive : protractorRefConfPath,
       noColor: false,
       debug: false,
       collectorPort: 3001,
@@ -121,7 +121,7 @@ module.exports = function(grunt) {
       //boolean
       "includeStackTrace", "verbose",
       //object
-      "params", "capabilities", "cucumberOpts"
+      "params", "capabilities", "cucumberOpts","keepAlive"
     ];
     var args = [protractorBinPath, opts.configFile];
     if (opts.noColor) {


### PR DESCRIPTION
Need to support keepAlive option. Currently, it's always true, which makes it impossible to stop the grunt when protractor tests fail.
